### PR TITLE
Refactor Gitweek Refresh Score Command.

### DIFF
--- a/src/Guide/Constants.cs
+++ b/src/Guide/Constants.cs
@@ -9,8 +9,8 @@ namespace Guide
         public const string LanguageFile = "Lang/english.json";
 
 #if DEBUG
-        public const ulong ScoreboardId = 560884884986527774;
-        public const ulong TutorialGuildId = 538334113019723776;
+        public const ulong ScoreboardId = 513467883825922063;
+        public const ulong TutorialGuildId = 513451922586468353;
         public const ulong WaitingRoomId = 560835975052263434;
         public const ulong GeneralId = 538334113501937667;
         public const ulong MemberRoleId = 560836164647649329;

--- a/src/Guide/GitWeek/GitweekStats.cs
+++ b/src/Guide/GitWeek/GitweekStats.cs
@@ -15,8 +15,8 @@ namespace Guide.GitWeek
         private const string FutureDayIcon = ":black_square_button:";
         private const string NoneDayIcon = ":black_medium_square:";
         
-        private readonly DateTime warmupStart = new DateTime(2019, 3, 28);
-        private readonly DateTime gitweekStart = new DateTime(2019, 3, 31);
+        public DateTime WarmupStart { get; set; } = new DateTime(2019, 3, 28);
+        public DateTime GitweekStart { get; set; } = new DateTime(2019, 3, 31);
         private readonly Regex commitRegex = new Regex("<rect .*?data-count=\"(\\d+)\" data-date=\"(\\d{4}-\\d{2}-\\d{2})\"\\/>");
         private readonly IGitUserVerification _verification;
         private readonly GitHubClient _github;
@@ -39,17 +39,17 @@ namespace Guide.GitWeek
             return users.OrderByDescending(u => u.CommitsByDate.Sum(c => c.Value)).Select(user => GetStats(user)).ToArray();
         }
 
-        private string GetStats(GitweekParticipant user)
+        public string GetStats(GitweekParticipant user)
         {
             var sb = new StringBuilder();
 
             var warmupCommits = user.CommitsByDate.Where(c =>
-                c.Key.Date >= warmupStart.Date &&
-                c.Key.Date <= gitweekStart.Date)
+                c.Key.Date >= WarmupStart.Date &&
+                c.Key.Date <= GitweekStart.Date)
                 .ToArray();
 
             var gitweekCommits = user.CommitsByDate.Where(c =>
-                c.Key.Date > gitweekStart.Date)
+                c.Key.Date > GitweekStart.Date)
                 .ToArray();
             
             sb.AppendLine($"__**{user.GitHubUsername}**__");
@@ -65,13 +65,13 @@ namespace Guide.GitWeek
         {
             var sb = new StringBuilder();
 
-            sb.Append(GetIconForDay(gitweekCommits, gitweekStart));
-            sb.Append(GetIconForDay(gitweekCommits, gitweekStart.AddDays(1)));
-            sb.Append(GetIconForDay(gitweekCommits, gitweekStart.AddDays(2)));
-            sb.Append(GetIconForDay(gitweekCommits, gitweekStart.AddDays(3)));
-            sb.Append(GetIconForDay(gitweekCommits, gitweekStart.AddDays(4)));
-            sb.Append(GetIconForDay(gitweekCommits, gitweekStart.AddDays(5)));
-            sb.Append(GetIconForDay(gitweekCommits, gitweekStart.AddDays(6)));
+            sb.Append(GetIconForDay(gitweekCommits, GitweekStart));
+            sb.Append(GetIconForDay(gitweekCommits, GitweekStart.AddDays(1)));
+            sb.Append(GetIconForDay(gitweekCommits, GitweekStart.AddDays(2)));
+            sb.Append(GetIconForDay(gitweekCommits, GitweekStart.AddDays(3)));
+            sb.Append(GetIconForDay(gitweekCommits, GitweekStart.AddDays(4)));
+            sb.Append(GetIconForDay(gitweekCommits, GitweekStart.AddDays(5)));
+            sb.Append(GetIconForDay(gitweekCommits, GitweekStart.AddDays(6)));
             
             return sb.ToString();
         }
@@ -83,10 +83,10 @@ namespace Guide.GitWeek
             sb.Append(NoneDayIcon);
             sb.Append(NoneDayIcon);
             sb.Append(NoneDayIcon);
-            sb.Append(GetIconForDay(warmupCommits, warmupStart));
-            sb.Append(GetIconForDay(warmupCommits, warmupStart.AddDays(1)));
-            sb.Append(GetIconForDay(warmupCommits, warmupStart.AddDays(2)));
-            sb.Append(GetIconForDay(warmupCommits, warmupStart.AddDays(3)));
+            sb.Append(GetIconForDay(warmupCommits, WarmupStart));
+            sb.Append(GetIconForDay(warmupCommits, WarmupStart.AddDays(1)));
+            sb.Append(GetIconForDay(warmupCommits, WarmupStart.AddDays(2)));
+            sb.Append(GetIconForDay(warmupCommits, WarmupStart.AddDays(3)));
             
             return sb.ToString();
         }
@@ -121,7 +121,7 @@ namespace Guide.GitWeek
                 foreach (Match match in matches)
                 {
                     var date = DateTime.Parse(match.Groups[2].Value);
-                    if (date.Date >= warmupStart.Date)
+                    if (date.Date >= WarmupStart.Date)
                     {
                         res.Add(date, int.Parse(match.Groups[1].Value));
                     }
@@ -132,6 +132,6 @@ namespace Guide.GitWeek
         }
 
         private bool IsGitweek()
-            => DateTime.Now < gitweekStart;
+            => DateTime.Now < GitweekStart;
     }
 }

--- a/src/Guide/GitWeek/IGitweekStats.cs
+++ b/src/Guide/GitWeek/IGitweekStats.cs
@@ -1,10 +1,14 @@
+using System;
 using System.Collections.Generic;
 
 namespace Guide.GitWeek
 {
     public interface IGitweekStats
     {
+        DateTime WarmupStart { get; set; }
+        DateTime GitweekStart { get; set; }
         IEnumerable<GitweekParticipant> GetParticipants();
         string[] GetLeaderboards();
+        string GetStats(GitweekParticipant user);
     }
 }

--- a/src/Guide/Modules/GitWeek.cs
+++ b/src/Guide/Modules/GitWeek.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
@@ -19,7 +20,7 @@ namespace Guide.Modules
             _gitweekStats = gitweekStats;
             _client = client;
         }
-        
+
         [Command("github register")]
         public async Task RegisterGitHub(string username)
         {
@@ -51,18 +52,48 @@ namespace Guide.Modules
             }
         }
 
-        [Command("refresh score")]
+        [Command("refresh score", RunMode = RunMode.Async)]
         [RequireUserPermission(GuildPermission.Administrator)]
         public async Task RefreshScore()
         {
             try
             {
                 await ReplyAsync("I'm on it. It will take some time in order to not spam GitHub (and get destroyed by Microsoft as a result).\n\nOh and Discord will not be happy with me posting so much stuff at once, so I'll go checkout r/unixporn each time they rate limit me. We could switch our IP and pretend to be a different shard but that sounds like work.");
+
                 var tutorialGuild = _client.GetGuild(Constants.TutorialGuildId);
                 var channel = tutorialGuild.GetTextChannel(Constants.ScoreboardId);
-                var users = _gitweekStats.GetLeaderboards();
-                foreach(var user in users)
-                    await channel.SendMessageAsync(user);
+                var participents = _gitweekStats.GetParticipants();
+                var leaderboardMessages = await channel.GetMessagesAsync(participents.Count()).FlattenAsync();
+
+                foreach (var participent in participents)
+                {
+                    var rankString = _gitweekStats.GetStats(participent);
+                    var userRankMessage = leaderboardMessages.FirstOrDefault(x => x.Content.Contains(participent.GitHubUsername)) as IUserMessage;
+
+                    if (userRankMessage is null)
+                    {
+                        await channel.SendMessageAsync(rankString);
+                    }
+                    else
+                    {
+                        var warmupCommits = participent.CommitsByDate.Where(c => 
+                                    c.Key.Date >= _gitweekStats.WarmupStart.Date &&
+                                    c.Key.Date <= _gitweekStats.GitweekStart.Date)
+                                    .ToArray();
+
+                        var gitweekCommits = participent.CommitsByDate.Where(c =>
+                                    c.Key.Date > _gitweekStats.GitweekStart.Date)
+                                    .ToArray();
+
+
+                        if (!userRankMessage.Content.Contains($"{warmupCommits.Sum(c => c.Value)} commits")
+                            || !userRankMessage.Content.Contains($"{gitweekCommits.Sum(c => c.Value)} commits"))
+                        {
+                            await userRankMessage.ModifyAsync(x => x.Content = rankString);
+                        }
+                    }
+                }
+
             }
             catch (Exception e)
             {


### PR DESCRIPTION
The Refresh Scores command will now only update a users score if it see's a change in commits. It will still post new users normally though. 

**Note!** This does not currently allow you to order the messages based on score now though.

**Extra Note:** It is damn ugly atm as I was busy as heck while doing it but it works. 😄 